### PR TITLE
Escape javascript in the feature name

### DIFF
--- a/lib/rollout/ui/helpers.rb
+++ b/lib/rollout/ui/helpers.rb
@@ -108,5 +108,9 @@ module Rollout::UI
         percentage: feature.percentage
       }
     end
+
+    def sanitized_name(feature_name)
+      Rack::Utils.escape_html(feature_name)
+    end
   end
 end

--- a/lib/rollout/ui/views/features/index.slim
+++ b/lib/rollout/ui/views/features/index.slim
@@ -45,13 +45,13 @@ h2.font-semibold.text-xl.text-gray-500.pt-12.flex.items-center
               = time_ago(@rollout.logging.updated_at(feature_name))
           td.flex.items-center.py-2.justify-end.whitespace-no-wrap.pl-3
             form action=activate_percentage_feature_path(feature_name, 100) method='POST'
-              button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want activate #{feature_name} to 100%?')")
+              button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want activate #{sanitized_name(feature_name)} to 100%?')")
                 ' 100%
             form action=activate_percentage_feature_path(feature_name, 0) method='POST'
-              button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want activate #{feature_name} to 0%?')")
+              button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want activate #{sanitized_name(feature_name)} to 0%?')")
                 ' 0%
             form action=delete_feature_path(feature_name) method='POST'
-              button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want to delete #{feature_name}?')")
+              button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want to delete #{sanitized_name(feature_name)}?')")
                 ' Delete
 
 - global_history_events = @rollout.respond_to?(:logging) ? @rollout.logging.global_events.reverse : []

--- a/lib/rollout/ui/views/features/show.slim
+++ b/lib/rollout/ui/views/features/show.slim
@@ -63,7 +63,7 @@ main.p-6.bg-gray-100.max-w-lg.w-full.text-sm.rounded-sm
 
   .flex.items-center.justify-end
     form action=delete_feature_path(@feature.name) method='POST'
-      button.mr-5.text-gray-600(class='hover:underline' type='submit' onclick="return confirm('Are you sure you want to delete #{@feature.name}?')")
+      button.mr-5.text-gray-600(class='hover:underline' type='submit' onclick="return confirm('Are you sure you want to delete #{sanitized_name(@feature.name)}?')")
         | Delete
     button.py-4.px-5.bg-gray-700.text-gray-200.rounded-sm.font-bold.leading-none.transition-colors.duration-200(
       type='submit'

--- a/lib/rollout/ui/web.rb
+++ b/lib/rollout/ui/web.rb
@@ -37,7 +37,7 @@ module Rollout::UI
 
     get '/features/:feature_name' do
       @rollout = config.get(:instance)
-      @feature = @rollout.get(Rack::Utils.escape_html(params[:feature_name]))
+      @feature = @rollout.get(params[:feature_name])
 
       if json_request?
         json(feature_to_hash(@feature))

--- a/lib/rollout/ui/web.rb
+++ b/lib/rollout/ui/web.rb
@@ -37,7 +37,7 @@ module Rollout::UI
 
     get '/features/:feature_name' do
       @rollout = config.get(:instance)
-      @feature = @rollout.get(params[:feature_name])
+      @feature = @rollout.get(Rack::Utils.escape_html(params[:feature_name]))
 
       if json_request?
         json(feature_to_hash(@feature))

--- a/spec/rollout/ui/web_spec.rb
+++ b/spec/rollout/ui/web_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe 'Web UI' do
     ROLLOUT.delete(:fake_test_feature_for_rollout_ui_webspec)
   end
 
+  it "rescapes javascript in the action index" do
+    ROLLOUT.activate(:'+alert(1)+')
+
+    get '/'
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to include('Rollout UI') & include("&amp;#x27;+alert(1)+&amp;#x27;")
+  end
+
   it "renders show html" do
     get '/features/test'
 

--- a/spec/rollout/ui/web_spec.rb
+++ b/spec/rollout/ui/web_spec.rb
@@ -79,12 +79,19 @@ RSpec.describe 'Web UI' do
     expect(last_response.body).to include('Rollout UI') & include('test')
   end
 
+  it "escapes javascript in the action show" do
+    get "/features/'+alert(1)+'"
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to include('Rollout UI') & include("&amp;#x27;+alert(1)+&amp;#x27;")
+  end
+
   it "renders show json" do
     ROLLOUT.activate(:fake_test_feature_for_rollout_ui_webspec)
     header 'Accept', 'application/json'
- 
+
     get '/features/fake_test_feature_for_rollout_ui_webspec'
- 
+
     expect(last_response).to be_ok
     expect(last_response.headers).to include('Content-Type' => 'application/json')
     response = JSON.parse(last_response.body)


### PR DESCRIPTION
**DO NOT MERGE**

The feature's name isn't escaped properly in the "Do you really want to delete" confirmation dialog. When the user clicks "Delete", the page will run the XSS from the feature name.

Example: `http://localhost:9292/features/'+alert(1)+'`

![Screen Shot 2023-01-26 at 11 43 09](https://user-images.githubusercontent.com/23173977/214865194-7ffb3b27-e453-4efd-b105-50456c939440.png)
